### PR TITLE
Allow request.Audio reader be streaming and minor API changes

### DIFF
--- a/directive.go
+++ b/directive.go
@@ -100,6 +100,7 @@ type Speak struct {
 	Payload struct {
 		Format string `json:"format"`
 		URL    string `json:"url"`
+		Token  string `json:"token"`
 	} `json:"payload"`
 }
 

--- a/event.go
+++ b/event.go
@@ -471,20 +471,36 @@ func NewExpectSpeechTimedOut(messageId string) *ExpectSpeechTimedOut {
 	return m
 }
 
+
+// RecognizeProfile identifies the ASR profile associated with your product.
+type RecognizeProfile string
+
+// Possible values for RecognizeProfile.
+// Supports three distinct profiles optimized for speech at varying distances.
+const (
+	RecognizeProfileCloseTalk = RecognizeProfile("CLOSE_TALK")
+	RecognizeProfileNearField = RecognizeProfile("NEAR_FIELD")
+	RecognizeProfileFarField  = RecognizeProfile("FAR_FIELD")
+)
+
 // The Recognize event.
 type Recognize struct {
 	*Message
 	Payload struct {
-		Profile string `json:"profile"`
-		Format  string `json:"format"`
+		Profile RecognizeProfile `json:"profile"`
+		Format  string           `json:"format"`
 	} `json:"payload"`
 }
 
 func NewRecognize(messageId, dialogRequestId string) *Recognize {
+	return NewRecognizeWithProfile(messageId, dialogRequestId, RecognizeProfileCloseTalk)
+}
+
+func NewRecognizeWithProfile(messageId, dialogRequestId string, profile RecognizeProfile) *Recognize {
 	m := new(Recognize)
 	m.Message = newEvent("SpeechRecognizer", "Recognize", messageId, dialogRequestId)
 	m.Payload.Format = "AUDIO_L16_RATE_16000_CHANNELS_1"
-	m.Payload.Profile = "CLOSE_TALK"
+	m.Payload.Profile = profile
 	return m
 }
 


### PR DESCRIPTION
When uploading a file, request.Audio (io.Reader) is used in an io.Copy to copy to the audio part of the upload. This works fine when request.Audio is a file but when request.Audio is a data stream (recording live) the HTTP request reads from the Body (a byte.Buffer) very quickly with a large buffer size and after 1 or 2 reads, gets an io.EOF because no more recorded data has been added to the buffer and finishes the request prematurely.

The implementation uses a blockingBuffer which returns the data in the buffer if any exists and blocks if the body is not finished (EOF) and there is no data. The blocking behavior in this case is desired to prevent the HTTP request from reading until more Audio data is written to the buffer.

The additional benefit of not blocking on the io.Copy is that the request can begin and (in NEAR_FIELD and FAR_FIELD profiles), AVS can begin processing the data and even return a directive before all of the audio is POSTed.

Additionally, two API changes were made.
1. Add Token to Speak directive (so SpeechStarted and SpeechFinished can re-use the token)
https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/reference/speechsynthesizer#speak
2. Enumerate and allow use of different Recognize Profiles. Previously was defaulted to "CLOSE_TALK"
https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/reference/speechrecognizer#profiles